### PR TITLE
Working Login / Logout / Join Pages

### DIFF
--- a/osCam/core/views.py
+++ b/osCam/core/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.http.response import StreamingHttpResponse
+from django.contrib.auth.decorators import login_required
 
 # Create your views here.
 import cv2 as cv
@@ -49,7 +50,7 @@ class MotionDetect():
             status_color=(0,255,0)
         cv.putText(frame, "Status: {}".format(text), (15,15), cv.FONT_HERSHEY_SIMPLEX, .5, status_color, 1)
         #current date/time
-        date_time = datetime.now() 
+        date_time = datetime.now()
         cv.putText(frame, "Date/Time: {}".format(date_time.strftime("%Y/%m/%d, %H:%M:%S")), (200,15), cv.FONT_HERSHEY_SIMPLEX, .5, status_color, 1)
         ret, jpeg = cv.imencode('.jpg', frame)
         if self.record:
@@ -106,6 +107,8 @@ class MotionDetect():
         width, height, channels = frame.shape
         #return output object
         return cv.VideoWriter(filePath, codec, fps, (height, width))
+
+@login_required
 def home(request):
     return render(request, 'core/home.html')
 

--- a/osCam/osCam/settings.py
+++ b/osCam/osCam/settings.py
@@ -122,4 +122,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
-STATICFILES_DIRS = [STATIC_DIR,]
+STATICFILES_DIRS = [STATIC_DIR]
+
+LOGIN_URL = '/login/'
+LOGIN_REDIRECT_URL = '/'

--- a/osCam/osCam/urls.py
+++ b/osCam/osCam/urls.py
@@ -17,11 +17,13 @@ from django.contrib import admin
 from django.urls import path
 from core import views as core_views
 from user import views as user_views
+from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', core_views.home, name='home'),
     path('feed/', core_views.feed, name='feed'),
     path('join/', user_views.join, name='join'),
-    path('login/', user_views.login, name='login'),
+    path('login/', auth_views.LoginView.as_view(), name='login'),
+    path('logout/', user_views.user_logout, name='logout')
 ]

--- a/osCam/templates/core/home.html
+++ b/osCam/templates/core/home.html
@@ -33,7 +33,7 @@
                     </p>
                 {% endif %}
               </div>
-              
+
               <div class="col-6">
                 <div class="row justify-content-md-center">
                     <!-- 2 of three columns -->
@@ -60,6 +60,8 @@
               </div> <!-- end of 3 of 3 col -->
             </div> <!-- end of row -->
         </div> <!-- end of container -->
-        <img src="{% url 'feed' %}">
+        {% if user.is_authenticated %}
+          <img src="{% url 'feed' %}">
+        {% endif %}
     </body>
 </html>

--- a/osCam/templates/registration/join.html
+++ b/osCam/templates/registration/join.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    {% include "../core/bootstrap.html" %}
+    {% load static %}
+  </head>
+  <body>
+    {% include "../core/navigation.html" %}
+    <div class="container">
+      <div class = "jumbotron">
+        <h1>Join</h1>
+        <form method="POST">{% csrf_token %}
+          <table>
+            {{ join_form.as_table }}
+            <tr><td>
+              <input type="submit" class="btn btn-primary" value = "Join"/>
+            </td></tr>
+          </table>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/osCam/templates/registration/login.html
+++ b/osCam/templates/registration/login.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    {% include "core/bootstrap.html" %}
+    {% load static %}
+  </head>
+  <body>
+    {% include "core/navigation.html" %}
+    <div class="container">
+      <div class = "jumbotron">
+        <h1>Login</h1>
+        <form action="/login/" method="POST">{% csrf_token %}
+          <table>
+            {{ form.errors }}
+            <label>{{ form.username.label_tag }}</label>
+            {{ form.username }} <br>
+            <label>{{ form.password.label_tag }}</label>
+            {{ form.password }} <br>
+            <tr><td>
+              <input type="submit" class="btn btn-primary" value = "Login"/>
+            </td></tr>
+            <tr><td>Click <a href="/join">here</a> to register.</td></tr>
+          </table>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/osCam/user/forms.py
+++ b/osCam/user/forms.py
@@ -17,7 +17,3 @@ class JoinForm(forms.ModelForm):
         help_texts = {
             'username': None
         }
-
-class LoginForm(forms.Form):
-    username = forms.CharField()
-    password = forms.CharField(widget=forms.PasswordInput())

--- a/osCam/user/views.py
+++ b/osCam/user/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse
 from django.contrib.auth import authenticate, login, logout
 from django.urls import reverse
 from django.contrib.auth.decorators import login_required
-from user.forms import JoinForm, LoginForm
+from user.forms import JoinForm
 
 # Create your views here.
 def join(request):
@@ -21,45 +21,15 @@ def join(request):
         else:
             # Form invalid, print errors to console
             page_data = { "join_form": join_form }
-            return render(request, 'app1/join.html', page_data)
+            return render(request, 'registration/join.html', page_data)
     else:
         join_form = JoinForm()
         page_data = { "join_form": join_form }
-        return render(request, 'user/join.html', page_data)
-
-def login(request):
-    if (request.method == 'POST'):
-        login_form = LoginForm(request.POST)
-        if login_form.is_valid():
-            # First get the username and password supplied
-            # The default encryption algorithm is called PBKDF2 with a SHA256 hash
-            # but we can install custom encryption libraries if needed
-            username = login_form.cleaned_data["username"]
-            password = login_form.cleaned_data["password"]
-            # Django's built-in authentication function:
-            user = authenticate(username=username, password=password)
-            # If we have a user
-            if user:
-                #Check it the account is active
-                if user.is_active:
-                    # Log the user in.
-                    login(request,user)
-                    # Send the user back to homepage
-                    return redirect("/")
-                else:
-                    # If account is not active:
-                    return HttpResponse("Your account is not active.")
-            else:
-                print("Someone tried to login and failed.")
-                print("They used username: {} and password: {}".format(username,password))
-                return render(request, 'user/login.html', {"login_form": LoginForm})
-    else:
-        #Nothing has been provided for username or password.
-        return render(request, 'user/login.html', {"login_form": LoginForm})
+        return render(request, 'registration/join.html', page_data)
 
 @login_required(login_url='/login/')
 def user_logout(request):
     # Log out the user.
     logout(request)
     # Return to homepage.
-    return redirect("/")
+    return redirect("/login/")


### PR DESCRIPTION
I reorganized the login/join pages into a registration folder. Doing this allows us to remove the login view and use the built in Django authentication system instead. Moving forward we should be able to now just include the "@login_required" decorator for areas of the website where it is necessary.